### PR TITLE
fix: revert timezone bug fix

### DIFF
--- a/pkg/epss/service.go
+++ b/pkg/epss/service.go
@@ -202,7 +202,7 @@ func (a *APIAgent) Read(p []byte) (int, error) {
 		return a.gunzipReader.Read(p)
 	}
 
-	today := time.Now().UTC()
+	today := time.Now()
 	endpoint := fmt.Sprintf("epss_scores-%d-%s-%s.csv.gz", today.Year(), today.Format("01"), today.Format("02"))
 	url, _ := url.JoinPath(a.url, endpoint)
 	req, _ := http.NewRequest(http.MethodGet, url, nil)


### PR DESCRIPTION
Revert `time.Now().UTC()` back to `time.Now()`.

`time.Now().UTC()` is now hitting the previous API error while `time.Now()` is not and behaves as expected...